### PR TITLE
Allow EFS service for GS Admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Extend `GiantSwarmAdmin` policy to allow EFS service.
 - Extend all policies with `iam:TagRole` to fix missing tags.
-
-### Added
-
 - Extend `GiantSwarmAdmin` policy with permissions for policy view and last access service.
 
 ### Changed

--- a/admin-role/iam-policy.json
+++ b/admin-role/iam-policy.json
@@ -10,6 +10,7 @@
                 "dynamodb:*",
                 "ec2:*",
                 "ecr:*",
+                "elasticfilesystem:*",
                 "elasticloadbalancing:*",
                 "events:*",
                 "iam:AddRoleToInstanceProfile",


### PR DESCRIPTION
This is necessary to create EFS so that efs-csi-driver inside kubernetes can mount NFS share.

![image](https://user-images.githubusercontent.com/1936982/106916547-98262200-6707-11eb-9a46-5596e089f92b.png)
