### PR TITLE
capa-controller-role - Add CreateNetworkInterface permission to resolver-rules-operator-policy

### DIFF
--- a/capa-controller-role/resolver-rules-operator-policy.json
+++ b/capa-controller-role/resolver-rules-operator-policy.json
@@ -12,7 +12,8 @@
 		"ec2:AuthorizeSecurityGroupIngress",
                 "ram:*",
 		"sts:AssumeRole",
-		"route53resolver:*"
+		"route53resolver:*",
+		"ec2:CreateNetworkInterface"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
Without `ec2:CreateNetworkInterface` the endpoints created by resolver-rules operator are stuck in failed state.

![image](https://user-images.githubusercontent.com/5674762/212679830-f8c97ecc-baf3-48ed-8c62-47a374437318.png)


Thread: https://gigantic.slack.com/archives/C03LV8E0RL7/p1673858060863559