### PR TITLE
Update CHANGELOG - Add `ec2:CreateNetworkInterface` permission for resolver rules operator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `sqs:*` permission to admin role.
 - Add `iam:*OpenIDConnectProvider` permissions to support IAM roles for service accounts.
 - Add `s3:PutObjectAcl` for uploading public objects.
+- Add `ec2:CreateNetworkInterface` permission for resolver rules operator.
 
 ### Changed
 


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm-aws-account-prerequisites/pull/53