### PR TITLE
Add IAM policy for use with Crossplane AWS provider

### DIFF
--- a/capa-controller-role/README.md
+++ b/capa-controller-role/README.md
@@ -3,7 +3,7 @@ If you don't know what the `INSTALLATION_NAME` value is supposed to be, ask Gian
 
 ## with aws cli
 ### requirements
-- `awscli` installed 
+- `awscli` installed
 - `envsubst` tool
 - `jq` installed
 - working AWS credentials set to the desired target account
@@ -44,6 +44,9 @@ aws iam attach-role-policy --role-name "${ROLE_NAME}" --policy-arn "${RESOLVER_R
 
 MC_BOOTSTRAP_POLICY_ARN=$(aws iam create-policy --policy-name "giantswarm-${INSTALLATION_NAME}-mc-bootstrap-policy" --description "Giant Swarm managed policy for k8s cluster cleanup" --policy-document file://mc-bootstrap-policy.json | jq -r '.Policy.Arn')
 aws iam attach-role-policy --role-name "${ROLE_NAME}" --policy-arn "${MC_BOOTSTRAP_POLICY_ARN}"
+
+CROSSPLANE_ARN=$(aws iam create-policy --policy-name "giantswarm-${INSTALLATION_NAME}-crossplane-policy" --description "Giant Swarm managed policy for k8s cluster creation" --policy-document file://crossplane-policy.json  | jq -r '.Policy.Arn')
+aws iam attach-role-policy --role-name "${ROLE_NAME}" --policy-arn "${CROSSPLANE_ARN}"
 ```
 
 ### for cleanup execute
@@ -59,7 +62,7 @@ chmod +x cleanup.sh
 - working AWS credentials set to the desired target account
 - AWS region has to be set  either via aws profile or via env `AWS_REGION`
 
-### adjust `variables.tf` 
+### adjust `variables.tf`
 - `principal_arns_giantswarm_root_account` - can be adjusted to be more strict and specify user which will assume the role - ie `arn:aws:iam::084190472784:user/${INSTALLATION_NAME}-capa-controller`
 
 ### execute

--- a/capa-controller-role/cleanup.sh
+++ b/capa-controller-role/cleanup.sh
@@ -10,7 +10,7 @@ NC='\033[0m'
 ROLE_NAME="giantswarm-${INSTALLATION_NAME}-capa-controller"
 AWS_ACCOUNT_ID="$(aws sts get-caller-identity --output text --query 'Account')"
 
-POL_TYPES=("capa-controller" "dns-controller" "eks-controller" "iam-controller" "irsa-controller" "resolver-rule-operator" "network-topology-controller" "mc-bootstrap")
+POL_TYPES=("capa-controller" "dns-controller" "eks-controller" "iam-controller" "irsa-controller" "resolver-rule-operator" "network-topology-controller" "mc-bootstrap" "crossplane")
 POL_ARN_PREFIX="arn:aws:iam::${AWS_ACCOUNT_ID}:policy"
 
 function echo_fail_or_success {
@@ -32,7 +32,7 @@ for pol_type in ${POL_TYPES[@]}; do
 	echo_fail_or_success "$?"
 
 	echo -n "|_ Delete policy ${POL_NAME}..."
-	aws iam delete-policy --policy-arn "${POL_ARN}"	
+	aws iam delete-policy --policy-arn "${POL_ARN}"
 	echo_fail_or_success "$?"
 done
 

--- a/capa-controller-role/crossplane-policy.json
+++ b/capa-controller-role/crossplane-policy.json
@@ -1,0 +1,19 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:DescribeSecurityGroupRules",
+                "ec2:DescribeSecurityGroups",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/capa-controller-role/giantswarm-capa-role.tf
+++ b/capa-controller-role/giantswarm-capa-role.tf
@@ -87,3 +87,12 @@ resource "aws_iam_role_policy_attachment" "giantswarm-mc-bootstrap-policy-attach
   role       = aws_iam_role.giantswarm-capa-controller-role.name
   policy_arn = aws_iam_policy.giantswarm-mc-bootstrap-policy.arn
 }
+
+resource "aws_iam_policy" "giantswarm-crossplane-policy" {
+  name   = "giantswarm-${var.installation_name}-crossplane-policy"
+  policy = file("${path.module}/crossplane-policy.json")
+}
+resource "aws_iam_role_policy_attachment" "giantswarm-crossplane-policy-attachment" {
+  role       = aws_iam_role.giantswarm-capa-controller-role.name
+  policy_arn = aws_iam_policy.giantswarm-crossplane-policy.arn
+}

--- a/capa-controller-role/variables.tf
+++ b/capa-controller-role/variables.tf
@@ -6,6 +6,6 @@ variable "principal_arns_giantswarm_root_account" {
 }
 
 variable "installation_name" {
-  type = string
+  type        = string
   description = "If you dont know what `installation_name` value is suppose to be, ask Giant Swarm staff and they will provide it."
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2563

The initial permissions are meant to be used with Cilium ENI mode (see Crossplane CRs in https://github.com/giantswarm/cluster-aws).