### PR TITLE
Add ReplaceRoute to the capa-controller-policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `ec2:ReplaceRoute` permissions to the CAPA controller role
+
 ### Added
 
 - For cluster cleanup purposes, add the permissions `s3:GetBucketTagging` and `s3:ListAllMyBuckets` in order to scan for buckets owned by a management/workload cluster. Those buckets may not have a fixed name pattern (e.g. include AWS region or other dynamic string) and therefore searching by "owned" tag allows us to find and delete all such resources.

--- a/capa-controller-role/capa-controller-policy.json
+++ b/capa-controller-role/capa-controller-policy.json
@@ -56,6 +56,7 @@
                 "ec2:ModifyNetworkInterfaceAttribute",
                 "ec2:ModifySubnetAttribute",
                 "ec2:ReleaseAddress",
+                "ec2:ReplaceRoute",
                 "ec2:RevokeSecurityGroupIngress",
                 "ec2:RevokeSecurityGroupEgress",
                 "ec2:RunInstances",


### PR DESCRIPTION
In certain circumstances, CAPA tries to replace routes but gets blocked by IAM policy. This causes nodes to spin up in a `not-ready` state

changelog

## Checklist

- [x] Update changelog in CHANGELOG.md.
