### PR TITLE
Add ec2:DescribeDhcpOptions permissions to capa controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `ec2:ReplaceRoute` permissions to the CAPA controller role.
-- Add `ec2:DescribeDhcpOptions` permissions to the CAPA controller role.
+- Add `ec2:DescribeDhcpOptions` permissions to the CAPA controller role, required by CAPA releases >= `v2.4.0`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add `ec2:ReplaceRoute` permissions to the CAPA controller role
+### Added
+
+- Add `ec2:ReplaceRoute` permissions to the CAPA controller role.
+- Add `ec2:DescribeDhcpOptions` permissions to the CAPA controller role.
 
 ### Added
 

--- a/capa-controller-role/capa-controller-policy.json
+++ b/capa-controller-role/capa-controller-policy.json
@@ -33,6 +33,7 @@
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAddresses",
                 "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeDhcpOptions",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInternetGateways",

--- a/capa-controller-role/cloud-formation-template.yaml
+++ b/capa-controller-role/cloud-formation-template.yaml
@@ -63,6 +63,7 @@ Resources:
               - "ec2:DescribeAccountAttributes"
               - "ec2:DescribeAddresses"
               - "ec2:DescribeAvailabilityZones"
+              - "ec2:DescribeDhcpOptions"
               - "ec2:DescribeInstances"
               - "ec2:DescribeInstanceTypes"
               - "ec2:DescribeInternetGateways"


### PR DESCRIPTION
CAPA 2.4.x requires this new permission.

## Checklist

- [X] Update changelog in CHANGELOG.md.
