### PR TITLE
Configure CAPA controller role to allow Crossplane to use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add support for Crossplane usage on the CAPA controller role
+
 ### Fixed
 
 - Fixed terraform file to use correct GiantSwarm root account for the user that will assume the capa-controller role.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Review the changes and click `Create stack`. In case of any error, please check 
 ### Execution
 
 ```
-terraform init .
+terraform init
 terraform apply -var="admin_role_name=GiantSwarmAdmin
 ```
 
@@ -80,8 +80,8 @@ Review the changes and click `Create stack`. In case of any error, please check 
 ### Execution
 
 ```
-terraform init .
-terraform apply -var="installation_name=test"
+terraform init
+terraform apply -var="installation_name=test" -var="management_cluster_oidc_provider_domain=irsa.test.gaws.gigantic.io"
 ```
 
 ## AWS cli

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ In the AWS account where you plan to run the management cluster, you need to cre
 
 ### AWS CloudFormation template
 
-You can execute directly the CloudFormation template by clicking the [capa controller role stack template](https://eu-central-1.console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/quickcreate?templateURL=https://cf-templates-giantswarm.s3.eu-central-1.amazonaws.com/capa-controller-role/cloud-formation-template.yaml&stackName=CAPAControllerRoleBootstrap&param_InstallationName=CHANGE_THIS_FOR_THE_INSTALLATION_NAME&param_ManagementClusterAccountID=MANAGEMENT_CLUSTER_ACCOUNT_ID) or uploading the [template file](./capa-controller-role/cloud-formation-template.yaml) when creating a new stack in the AWS console.
+You can execute directly the CloudFormation template by clicking the [capa controller role stack template](https://eu-central-1.console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/quickcreate?templateURL=https://cf-templates-giantswarm.s3.eu-central-1.amazonaws.com/capa-controller-role/cloud-formation-template.yaml&stackName=CAPAControllerRoleBootstrap&param_InstallationName=CHANGE_THIS_FOR_THE_INSTALLATION_NAME&param_ManagementClusterOidcProviderDomain=MANAGEMENT_CLUSTER_OIDC_PROVIDER_DOMAIN) or uploading the [template file](./capa-controller-role/cloud-formation-template.yaml) when creating a new stack in the AWS console.
 
 You will be asked for the following parameters:
 
-- `InstallationName`: The name of the installation which you have agreed with Giant Swarm upfront.
-- `ManagementClusterAccountID`: The account ID of the management cluster account. This is the account where the management cluster will be running.
+- `InstallationName`: the name of the installation which you have agreed with Giant Swarm upfront.
+- `ManagementClusterOidcProviderDomain`: the domain name used by the MC OIDC provider. Normally `irsa.<cluster-base-domain>`.
 
 Review the changes and click `Create stack`. In case of any error, please check the `Events` tab in the CloudFormation console and report the error to the Giant Swarm staff.
 
@@ -74,8 +74,8 @@ Review the changes and click `Create stack`. In case of any error, please check 
 
 ### Adjust variables
 
-- `management_cluster_account_id` - the account id of the management cluster account.
-- `installation_name` - the name of the installation which you have agreed with Giant Swarm upfront.
+- `installation_name`: the name of the installation which you have agreed with Giant Swarm upfront.
+- `management_cluster_oidc_provider_domain`: the domain name used by the MC OIDC provider. Normally `irsa.<cluster-base-domain>`.
 
 ### Execution
 
@@ -98,6 +98,7 @@ terraform apply -var="installation_name=test"
 
 ```
 export INSTALLATION_NAME=test
+export MANAGEMENT_CLUSTER_OIDC_PROVIDER_DOMAIN=irsa.test.gaws.gigantic.io
 chmod +x setup.sh
 ./setup.sh
 ```

--- a/capa-controller-role/cloud-formation-template.yaml
+++ b/capa-controller-role/cloud-formation-template.yaml
@@ -1,11 +1,11 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Description: CloudFormation template for bootstrapping the CAPA controller role in your AWS account.
 
 Parameters:
   InstallationName:
     Type: String
     Description: "The name of the management cluster."
-  ManagementClusterAccountID:
+  ManagementClusterOidcProviderDomain:
     Type: String
     Description: "The AWS account ID of the management cluster."
 
@@ -15,12 +15,26 @@ Resources:
     Properties:
       RoleName: !Sub "giantswarm-${InstallationName}-capa-controller"
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           - Effect: "Allow"
             Principal:
-              AWS: !Sub "arn:aws:iam::${ManagementClusterAccountID}:user/${InstallationName}-capa-controller"
+              AWS: !Sub "arn:aws:iam::084190472784:user/${InstallationName}-capa-controller"
             Action: "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/${ManagementClusterOidcProviderDomain}"
+            Action: "sts:AssumeRoleWithWebIdentity"
+            Condition: !Sub |
+              {
+                "ForAnyValue:StringEquals": {
+                  "${ManagementClusterOidcProviderDomain}:sub": [
+                    "system:serviceaccount:crossplane:upbound-provider-aws",
+                    "system:serviceaccount:crossplane:upbound-provider-aws-importer",
+                    "system:serviceaccount:crossplane:xfn-network-discovery"
+                  ]
+                }
+              }
       Tags:
         - Key: "installation"
           Value: !Ref InstallationName
@@ -217,6 +231,9 @@ Resources:
               - "ec2:DescribeSecurityGroups"
               - "ec2:RevokeSecurityGroupEgress"
               - "ec2:RevokeSecurityGroupIngress"
+              - "cloudwatch:*"
+              - "sqs:*"
+              - "events:*"
             Resource: "*"
       Roles:
         - !Ref GiantSwarmCapaControllerRole

--- a/capa-controller-role/cloud-formation-template.yaml
+++ b/capa-controller-role/cloud-formation-template.yaml
@@ -14,19 +14,24 @@ Resources:
     Type: "AWS::IAM::Role"
     Properties:
       RoleName: !Sub "giantswarm-${InstallationName}-capa-controller"
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Principal:
-              AWS: !Sub "arn:aws:iam::084190472784:user/${InstallationName}-capa-controller"
-            Action: "sts:AssumeRole"
-          - Effect: "Allow"
-            Principal:
-              Federated: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/${ManagementClusterOidcProviderDomain}"
-            Action: "sts:AssumeRoleWithWebIdentity"
-            Condition: !Sub |
-              {
+      AssumeRolePolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::084190472784:user/${InstallationName}-capa-controller"
+              },
+              "Action": "sts:AssumeRole"
+            },
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/${ManagementClusterOidcProviderDomain}"
+              },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
                 "ForAnyValue:StringEquals": {
                   "${ManagementClusterOidcProviderDomain}:sub": [
                     "system:serviceaccount:crossplane:upbound-provider-aws",
@@ -35,6 +40,9 @@ Resources:
                   ]
                 }
               }
+            }
+          ]
+        }
       Tags:
         - Key: "installation"
           Value: !Ref InstallationName

--- a/capa-controller-role/crossplane-policy.json
+++ b/capa-controller-role/crossplane-policy.json
@@ -11,7 +11,10 @@
                 "ec2:DescribeSecurityGroupRules",
                 "ec2:DescribeSecurityGroups",
                 "ec2:RevokeSecurityGroupEgress",
-                "ec2:RevokeSecurityGroupIngress"
+                "ec2:RevokeSecurityGroupIngress",
+                "cloudwatch:*",
+                "sqs:*",
+                "events:*"
             ],
             "Resource": "*"
         }

--- a/capa-controller-role/setup.sh
+++ b/capa-controller-role/setup.sh
@@ -7,6 +7,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
 ROLE_NAME="giantswarm-${INSTALLATION_NAME}-capa-controller"
 POL_TYPES=("capa-controller" "dns-controller" "eks-controller" "iam-controller" "irsa-operator" "resolver-rules-operator" "network-topology-operator" "mc-bootstrap" "crossplane")
 TAGS="Key=installation,Value=${INSTALLATION_NAME}"
@@ -21,6 +22,7 @@ function echo_fail_or_success {
 }
 
 function create_role {
+  export AWS_ACCOUNT_ID
   envsubst < ./trusted-entities.json > ${INSTALLATION_NAME}-trusted-entities.json
   aws iam create-role --role-name "${ROLE_NAME}" --description "Giant Swarm managed role for k8s cluster creation" --assume-role-policy-document file://${INSTALLATION_NAME}-trusted-entities.json --tags ${TAGS}
 	err=$?

--- a/capa-controller-role/trusted-entities.json
+++ b/capa-controller-role/trusted-entities.json
@@ -8,6 +8,22 @@
             },
             "Action": "sts:AssumeRole",
             "Condition": {}
+        },
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${MANAGEMENT_CLUSTER_OIDC_PROVIDER_DOMAIN}"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "ForAnyValue:StringEquals": {
+                    "${MANAGEMENT_CLUSTER_OIDC_PROVIDER_DOMAIN}:sub": [
+                        "system:serviceaccount:crossplane:upbound-provider-aws",
+                        "system:serviceaccount:crossplane:upbound-provider-aws-importer",
+                        "system:serviceaccount:crossplane:xfn-network-discovery"
+                    ]
+                }
+            }
         }
     ]
 }

--- a/capa-controller-role/variables.tf
+++ b/capa-controller-role/variables.tf
@@ -1,9 +1,9 @@
-variable "management_cluster_account_id" {
-  type        = string
-  description = "AWS account ID of the management cluster"
-}
-
 variable "installation_name" {
   type        = string
   description = "If you dont know what `installation_name` value is suppose to be, ask Giant Swarm staff and they will provide it."
+}
+
+variable "management_cluster_oidc_provider_domain" {
+  type        = string
+  description = "OIDC provider domain of the management cluster"
 }


### PR DESCRIPTION
This grants access to the Crossplane providers running on the MC to assume the CAPA controller role to perform actions on the target AWS account.

It also adds the necessary permissions to create the needed resources for Karpenter.

Since Crossplane uses IRSA, the installation OIDC domain is needed to configure the role trust policy.

## Checklist

- [x] Update changelog in CHANGELOG.md.
