### PR TITLE
Support importing existing resources for the CAPA controller role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .terraform*
+terraform.tfstate*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add support for Crossplane usage on the CAPA controller role
+- Add ability to import existing IAM resources into Terraform state for the CAPA controller role
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ terraform init
 terraform apply -var="installation_name=test" -var="management_cluster_oidc_provider_domain=irsa.test.gaws.gigantic.io"
 ```
 
+### Import existing resources
+
+To update the policies of an existing role, you can run Terraform with the extra variable `import_existing=true` to import the resources into the state:
+
+```
+terraform init
+terraform apply -var="installation_name=test" -var="management_cluster_oidc_provider_domain=irsa.test.gaws.gigantic.io" -var="import_existing=true"
+```
+
 ## AWS cli
 
 ### Requirements

--- a/capa-controller-role/giantswarm-capa-role.tf
+++ b/capa-controller-role/giantswarm-capa-role.tf
@@ -4,6 +4,12 @@ locals {
   }
 }
 
+provider "aws" {
+  ignore_tags {
+    keys = ["maintainer", "owner", "repo"]
+  }
+}
+
 data "aws_caller_identity" "current" {}
 
 resource "aws_iam_role" "giantswarm-capa-controller-role" {

--- a/capa-controller-role/import.tf
+++ b/capa-controller-role/import.tf
@@ -1,0 +1,117 @@
+locals {
+  existing_install_for_each = var.import_existing ? toset([1]) : toset([])
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_role.giantswarm-capa-controller-role
+  id = "giantswarm-${var.installation_name}-capa-controller"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_policy.giantswarm-capa-controller-policy
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-capa-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_role_policy_attachment.giantswarm-capa-controller-policy-attachment
+  id = "giantswarm-${var.installation_name}-capa-controller/arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-capa-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_policy.giantswarm-dns-controller-policy
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-dns-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_role_policy_attachment.giantswarm-dns-controller-policy-attachment
+  id = "giantswarm-${var.installation_name}-capa-controller/arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-dns-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_policy.giantswarm-eks-controller-policy
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-eks-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_role_policy_attachment.giantswarm-eks-controller-policy-attachment
+  id = "giantswarm-${var.installation_name}-capa-controller/arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-eks-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_policy.giantswarm-iam-controller-policy
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-iam-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_role_policy_attachment.giantswarm-iam-controller-policy-attachment
+  id = "giantswarm-${var.installation_name}-capa-controller/arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-iam-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_policy.giantswarm-irsa-controller-policy
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-irsa-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_role_policy_attachment.giantswarm-irsa-controller-policy-attachment
+  id = "giantswarm-${var.installation_name}-capa-controller/arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-irsa-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_policy.giantswarm-network-topology-controller-policy
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-network-topology-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_role_policy_attachment.giantswarm-network-topology-controller-policy-attachment
+  id = "giantswarm-${var.installation_name}-capa-controller/arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-network-topology-controller-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_policy.giantswarm-resolver-rules-operator-policy
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-resolver-rules-operator-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_role_policy_attachment.giantswarm-resolver-rules-operator-policy-attachment
+  id = "giantswarm-${var.installation_name}-capa-controller/arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-resolver-rules-operator-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_policy.giantswarm-mc-bootstrap-policy
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-mc-bootstrap-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_role_policy_attachment.giantswarm-mc-bootstrap-policy-attachment
+  id = "giantswarm-${var.installation_name}-capa-controller/arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-mc-bootstrap-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_policy.giantswarm-crossplane-policy
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-crossplane-policy"
+}
+
+import {
+  for_each = local.existing_install_for_each
+  to = aws_iam_role_policy_attachment.giantswarm-crossplane-policy-attachment
+  id = "giantswarm-${var.installation_name}-capa-controller/arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/giantswarm-${var.installation_name}-crossplane-policy"
+}

--- a/capa-controller-role/variables.tf
+++ b/capa-controller-role/variables.tf
@@ -7,3 +7,9 @@ variable "management_cluster_oidc_provider_domain" {
   type        = string
   description = "OIDC provider domain of the management cluster"
 }
+
+variable "import_existing" {
+  type        = bool
+  description = "If true, import existing resources"
+  default     = false
+}


### PR DESCRIPTION
This adds support for importing existing resources (role & policies) into the terraform state for the CAPA controller role. Useful in case an update to the policies is needed.

## Checklist

- [x] Update changelog in CHANGELOG.md.
