### PR TITLE
Fix VPC policy in CAPA controller role CloudFormation template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add support for removing some IAM permissions from the capa controller role in BYOVPC installations.
+- CAPA role CloudFormation template: switch from inline to managed policies for the CAPA IAM role.
 
 ## [4.2.0] - 2024-09-04
 

--- a/capa-controller-role/cloud-formation-template.yaml
+++ b/capa-controller-role/cloud-formation-template.yaml
@@ -230,6 +230,9 @@ Resources:
               - "ec2:DisassociateVpcCidrBlock"
               - "ec2:ModifySubnetAttribute"
               - "ec2:ReplaceRoute"
+            Resource: "*"
+      Roles:
+        - !Ref GiantSwarmCapaControllerRole
 
   GiantSwarmDNSControllerPolicy:
     Type: "AWS::IAM::Policy"

--- a/capa-controller-role/cloud-formation-template.yaml
+++ b/capa-controller-role/cloud-formation-template.yaml
@@ -60,10 +60,10 @@ Resources:
         - Key: "installation"
           Value: !Ref InstallationName
 
-  GiantSwarmCapaControllerPolicy:
-    Type: "AWS::IAM::Policy"
+  GiantSwarmCapaControllerManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "giantswarm-${InstallationName}-capa-controller-policy"
+      ManagedPolicyName: !Sub "giantswarm-${InstallationName}-capa-controller-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -197,11 +197,11 @@ Resources:
       Roles:
         - !Ref GiantSwarmCapaControllerRole
 
-  GiantSwarmCapaControllerPolicyVpc:
+  GiantSwarmCapaControllerVpcManagedPolicy:
     Condition: CreateVpcPolicy
-    Type: "AWS::IAM::Policy"
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "giantswarm-${InstallationName}-capa-controller-policy-vpc"
+      ManagedPolicyName: !Sub "giantswarm-${InstallationName}-capa-controller-vpc-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -234,10 +234,10 @@ Resources:
       Roles:
         - !Ref GiantSwarmCapaControllerRole
 
-  GiantSwarmDNSControllerPolicy:
-    Type: "AWS::IAM::Policy"
+  GiantSwarmDNSControllerManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "giantswarm-${InstallationName}-dns-controller-policy"
+      ManagedPolicyName: !Sub "giantswarm-${InstallationName}-dns-controller-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -250,10 +250,10 @@ Resources:
       Roles:
         - !Ref GiantSwarmCapaControllerRole
 
-  GiantSwarmCrossplanePolicy:
-    Type: "AWS::IAM::Policy"
+  GiantSwarmCrossplaneManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "giantswarm-${InstallationName}-crossplane-policy"
+      ManagedPolicyName: !Sub "giantswarm-${InstallationName}-crossplane-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -274,10 +274,10 @@ Resources:
       Roles:
         - !Ref GiantSwarmCapaControllerRole
 
-  GiantSwarmEKSControllerPolicy:
-    Type: "AWS::IAM::Policy"
+  GiantSwarmEKSControllerManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "giantswarm-${InstallationName}-eks-controller-policy"
+      ManagedPolicyName: !Sub "giantswarm-${InstallationName}-eks-controller-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -372,10 +372,10 @@ Resources:
       Roles:
         - !Ref GiantSwarmCapaControllerRole
 
-  GiantSwarmIAMControllerPolicy:
-    Type: "AWS::IAM::Policy"
+  GiantSwarmIAMControllerManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "giantswarm-${InstallationName}-iam-controller-policy"
+      ManagedPolicyName: !Sub "giantswarm-${InstallationName}-iam-controller-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -404,10 +404,10 @@ Resources:
       Roles:
         - !Ref GiantSwarmCapaControllerRole
 
-  GiantSwarmIRSAControllerPolicy:
-    Type: "AWS::IAM::Policy"
+  GiantSwarmIRSAControllerManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "giantswarm-${InstallationName}-irsa-controller-policy"
+      ManagedPolicyName: !Sub "giantswarm-${InstallationName}-irsa-controller-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -466,10 +466,10 @@ Resources:
       Roles:
         - !Ref GiantSwarmCapaControllerRole
 
-  GiantSwarmMCBootstrapPolicy:
-    Type: "AWS::IAM::Policy"
+  GiantSwarmMCBootstrapManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "giantswarm-${InstallationName}-mc-bootstrap-policy"
+      ManagedPolicyName: !Sub "giantswarm-${InstallationName}-mc-bootstrap-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -479,10 +479,10 @@ Resources:
       Roles:
         - !Ref GiantSwarmCapaControllerRole
 
-  GiantSwarmNetworkTopologyControllerPolicy:
-    Type: "AWS::IAM::Policy"
+  GiantSwarmNetworkTopologyControllerManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "giantswarm-${InstallationName}-network-topology-controller-policy"
+      ManagedPolicyName: !Sub "giantswarm-${InstallationName}-network-topology-controller-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -509,10 +509,10 @@ Resources:
       Roles:
         - !Ref GiantSwarmCapaControllerRole
 
-  GiantSwarmResolverRulesOperatorPolicy:
-    Type: "AWS::IAM::Policy"
+  GiantSwarmResolverRulesOperatorManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "giantswarm-${InstallationName}-resolver-rules-operator-policy"
+      ManagedPolicyName: !Sub "giantswarm-${InstallationName}-resolver-rules-operator-policy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32065

Turns out that with the split-out policy, we're now over the 10240 bytes limit for inline policies 😕 

```
Maximum policy size of 10240 bytes exceeded for role giantswarm-alba-capa-controller
```

So even though this fixes the CF template, it's still not usable... I guess the solution would be to refactor it completely to use managed policies, but not sure if it's possible in CF.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
