### PR TITLE
Avoid Terraform replacing IAM role/policies if only description field changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Allow `iam:TagPolicy` to GS staff in order to update prerequisites IAM policies
+- Avoid Terraform replacing IAM role/policies if only description field changed
 
 ## [4.3.0] - 2024-12-05
 

--- a/capa-controller-role/giantswarm-capa-role.tf
+++ b/capa-controller-role/giantswarm-capa-role.tf
@@ -21,13 +21,23 @@ resource "aws_iam_role" "giantswarm-capa-controller-role" {
     AWS_PARTITION                           = var.aws_partition
     GS_USER_ACCOUNT                         = var.gs_user_account
   })
-  tags = local.tags
+  tags        = local.tags
+  description = "Giant Swarm managed role for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 
 resource "aws_iam_policy" "giantswarm-capa-controller-policy" {
-  name   = "giantswarm-${var.installation_name}-capa-controller-policy"
-  policy = file("${path.module}/capa-controller-policy.json")
-  tags   = local.tags
+  name        = "giantswarm-${var.installation_name}-capa-controller-policy"
+  policy      = file("${path.module}/capa-controller-policy.json")
+  tags        = local.tags
+  description = "Giant Swarm managed policy for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 resource "aws_iam_role_policy_attachment" "giantswarm-capa-controller-policy-attachment" {
   role       = aws_iam_role.giantswarm-capa-controller-role.name
@@ -35,10 +45,15 @@ resource "aws_iam_role_policy_attachment" "giantswarm-capa-controller-policy-att
 }
 
 resource "aws_iam_policy" "giantswarm-capa-controller-vpc-policy" {
-  count  = var.byovpc ? 0 : 1 # This policy is not needed in BYO VPC installations
-  name   = "giantswarm-${var.installation_name}-capa-controller-vpc-policy"
-  policy = file("${path.module}/capa-controller-vpc-policy.json")
-  tags   = local.tags
+  count       = var.byovpc ? 0 : 1 # This policy is not needed in BYO VPC installations
+  name        = "giantswarm-${var.installation_name}-capa-controller-vpc-policy"
+  policy      = file("${path.module}/capa-controller-vpc-policy.json")
+  tags        = local.tags
+  description = "Giant Swarm managed policy for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 resource "aws_iam_role_policy_attachment" "giantswarm-capa-controller-vpc-policy-attachment" {
   count      = var.byovpc ? 0 : 1 # This policy is not needed in BYO VPC installations
@@ -47,9 +62,14 @@ resource "aws_iam_role_policy_attachment" "giantswarm-capa-controller-vpc-policy
 }
 
 resource "aws_iam_policy" "giantswarm-dns-controller-policy" {
-  name   = "giantswarm-${var.installation_name}-dns-controller-policy"
-  policy = file("${path.module}/dns-controller-policy.json")
-  tags   = local.tags
+  name        = "giantswarm-${var.installation_name}-dns-controller-policy"
+  policy      = file("${path.module}/dns-controller-policy.json")
+  tags        = local.tags
+  description = "Giant Swarm managed policy for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 resource "aws_iam_role_policy_attachment" "giantswarm-dns-controller-policy-attachment" {
   role       = aws_iam_role.giantswarm-capa-controller-role.name
@@ -57,9 +77,14 @@ resource "aws_iam_role_policy_attachment" "giantswarm-dns-controller-policy-atta
 }
 
 resource "aws_iam_policy" "giantswarm-eks-controller-policy" {
-  name   = "giantswarm-${var.installation_name}-eks-controller-policy"
-  policy = file("${path.module}/eks-controller-policy.json")
-  tags   = local.tags
+  name        = "giantswarm-${var.installation_name}-eks-controller-policy"
+  policy      = file("${path.module}/eks-controller-policy.json")
+  tags        = local.tags
+  description = "Giant Swarm managed policy for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 resource "aws_iam_role_policy_attachment" "giantswarm-eks-controller-policy-attachment" {
   role       = aws_iam_role.giantswarm-capa-controller-role.name
@@ -67,9 +92,14 @@ resource "aws_iam_role_policy_attachment" "giantswarm-eks-controller-policy-atta
 }
 
 resource "aws_iam_policy" "giantswarm-iam-controller-policy" {
-  name   = "giantswarm-${var.installation_name}-iam-controller-policy"
-  policy = file("${path.module}/iam-controller-policy.json")
-  tags   = local.tags
+  name        = "giantswarm-${var.installation_name}-iam-controller-policy"
+  policy      = file("${path.module}/iam-controller-policy.json")
+  tags        = local.tags
+  description = "Giant Swarm managed policy for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 resource "aws_iam_role_policy_attachment" "giantswarm-iam-controller-policy-attachment" {
   role       = aws_iam_role.giantswarm-capa-controller-role.name
@@ -77,9 +107,14 @@ resource "aws_iam_role_policy_attachment" "giantswarm-iam-controller-policy-atta
 }
 
 resource "aws_iam_policy" "giantswarm-irsa-controller-policy" {
-  name   = "giantswarm-${var.installation_name}-irsa-controller-policy"
-  policy = file("${path.module}/irsa-operator-policy.json")
-  tags   = local.tags
+  name        = "giantswarm-${var.installation_name}-irsa-controller-policy"
+  policy      = file("${path.module}/irsa-operator-policy.json")
+  tags        = local.tags
+  description = "Giant Swarm managed policy for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 resource "aws_iam_role_policy_attachment" "giantswarm-irsa-controller-policy-attachment" {
   role       = aws_iam_role.giantswarm-capa-controller-role.name
@@ -87,9 +122,14 @@ resource "aws_iam_role_policy_attachment" "giantswarm-irsa-controller-policy-att
 }
 
 resource "aws_iam_policy" "giantswarm-network-topology-controller-policy" {
-  name   = "giantswarm-${var.installation_name}-network-topology-controller-policy"
-  policy = file("${path.module}/network-topology-operator-policy.json")
-  tags   = local.tags
+  name        = "giantswarm-${var.installation_name}-network-topology-controller-policy"
+  policy      = file("${path.module}/network-topology-operator-policy.json")
+  tags        = local.tags
+  description = "Giant Swarm managed policy for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 resource "aws_iam_role_policy_attachment" "giantswarm-network-topology-controller-policy-attachment" {
   role       = aws_iam_role.giantswarm-capa-controller-role.name
@@ -97,9 +137,14 @@ resource "aws_iam_role_policy_attachment" "giantswarm-network-topology-controlle
 }
 
 resource "aws_iam_policy" "giantswarm-resolver-rules-operator-policy" {
-  name   = "giantswarm-${var.installation_name}-resolver-rules-operator-policy"
-  policy = file("${path.module}/resolver-rules-operator-policy.json")
-  tags   = local.tags
+  name        = "giantswarm-${var.installation_name}-resolver-rules-operator-policy"
+  policy      = file("${path.module}/resolver-rules-operator-policy.json")
+  tags        = local.tags
+  description = "Giant Swarm managed policy for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 resource "aws_iam_role_policy_attachment" "giantswarm-resolver-rules-operator-policy-attachment" {
   role       = aws_iam_role.giantswarm-capa-controller-role.name
@@ -107,9 +152,14 @@ resource "aws_iam_role_policy_attachment" "giantswarm-resolver-rules-operator-po
 }
 
 resource "aws_iam_policy" "giantswarm-mc-bootstrap-policy" {
-  name   = "giantswarm-${var.installation_name}-mc-bootstrap-policy"
-  policy = file("${path.module}/mc-bootstrap-policy.json")
-  tags   = local.tags
+  name        = "giantswarm-${var.installation_name}-mc-bootstrap-policy"
+  policy      = file("${path.module}/mc-bootstrap-policy.json")
+  tags        = local.tags
+  description = "Giant Swarm managed policy for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 resource "aws_iam_role_policy_attachment" "giantswarm-mc-bootstrap-policy-attachment" {
   role       = aws_iam_role.giantswarm-capa-controller-role.name
@@ -117,9 +167,14 @@ resource "aws_iam_role_policy_attachment" "giantswarm-mc-bootstrap-policy-attach
 }
 
 resource "aws_iam_policy" "giantswarm-crossplane-policy" {
-  name   = "giantswarm-${var.installation_name}-crossplane-policy"
-  policy = file("${path.module}/crossplane-policy.json")
-  tags   = local.tags
+  name        = "giantswarm-${var.installation_name}-crossplane-policy"
+  policy      = file("${path.module}/crossplane-policy.json")
+  tags        = local.tags
+  description = "Giant Swarm managed policy for k8s cluster creation"
+  lifecycle {
+    # Avoid recreation due to these fields in case the object was initially created with different values
+    ignore_changes = [description]
+  }
 }
 resource "aws_iam_role_policy_attachment" "giantswarm-crossplane-policy-attachment" {
   role       = aws_iam_role.giantswarm-capa-controller-role.name


### PR DESCRIPTION
Tag differences should make us apply them, but the description isn't that important. We use a description in our script, so consistently also apply it to new Terraform resources, but don't recreate them if there's a difference.

## Checklist

- [x] Update changelog in CHANGELOG.md.
