### PR TITLE
Fix the MC oidc provider variable definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `directconnect:*` permissions to admin role.
 - Add `cloudtrail:*` permissions to admin role.
 
+### Changed
+
+- Rename the `management_cluster_oidc_provider` variable of the `capa-controller-role` module to match its definition.
+
 ## [5.0.0] - 2025-01-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ But in case that for some reason the CAPA controller role needs to be managed in
 Note that for this stack there are some additional variables that you need to provide:
 
 - `installation_name`: the name of the installation which you have agreed with Giant Swarm upfront.
-- `management_cluster_oidc_provider_domain`: the domain name used by the MC OIDC provider. Normally `irsa.<cluster-base-domain>`.
+- `management_cluster_oidc_provider`: the name of the MC OIDC provider. Normally `irsa.<cluster-base-domain>`.
 - `byovpc` (optional - defaults to `false`): if `true`, the CAPA role will be created without the permissions needed to manage VPCs
 
 ### Execution
@@ -41,7 +41,7 @@ Note that for this stack there are some additional variables that you need to pr
 ```console
 export AWS_PROFILE=example
 export TF_VAR_installation_name=foo
-export TF_VAR_management_cluster_oidc_provider_domain=irsa.foo.bar.com
+export TF_VAR_management_cluster_oidc_provider=irsa.foo.bar.com
 export TF_VAR_byovpc=false
 tofu init
 tofu apply # review the proposed changes before approving

--- a/capa-controller-role/giantswarm-capa-role.tf
+++ b/capa-controller-role/giantswarm-capa-role.tf
@@ -19,11 +19,11 @@ data "aws_partition" "current" {}
 resource "aws_iam_role" "giantswarm_capa_controller_role" {
   name = "giantswarm-${var.installation_name}-capa-controller"
   assume_role_policy = templatefile("${path.module}/policies/trusted-entities.json", {
-    INSTALLATION_NAME                       = var.installation_name
-    AWS_ACCOUNT_ID                          = data.aws_caller_identity.current.account_id
-    MANAGEMENT_CLUSTER_OIDC_PROVIDER_DOMAIN = var.management_cluster_oidc_provider_domain
-    AWS_PARTITION                           = data.aws_partition.current.partition
-    GS_USER_ACCOUNT                         = var.gs_user_account
+    INSTALLATION_NAME                = var.installation_name
+    AWS_ACCOUNT_ID                   = data.aws_caller_identity.current.account_id
+    MANAGEMENT_CLUSTER_OIDC_PROVIDER = var.management_cluster_oidc_provider
+    AWS_PARTITION                    = data.aws_partition.current.partition
+    GS_USER_ACCOUNT                  = var.gs_user_account
   })
   tags        = local.tags
   description = "Giant Swarm managed role for k8s cluster creation"

--- a/capa-controller-role/policies/trusted-entities.json
+++ b/capa-controller-role/policies/trusted-entities.json
@@ -12,12 +12,12 @@
         {
             "Effect": "Allow",
             "Principal": {
-                "Federated": "arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:oidc-provider/${MANAGEMENT_CLUSTER_OIDC_PROVIDER_DOMAIN}"
+                "Federated": "arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:oidc-provider/${MANAGEMENT_CLUSTER_OIDC_PROVIDER}"
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "ForAnyValue:StringEquals": {
-                    "${MANAGEMENT_CLUSTER_OIDC_PROVIDER_DOMAIN}:sub": [
+                    "${MANAGEMENT_CLUSTER_OIDC_PROVIDER}:sub": [
                         "system:serviceaccount:crossplane:upbound-provider-aws",
                         "system:serviceaccount:crossplane:upbound-provider-aws-importer",
                         "system:serviceaccount:crossplane:xfn-network-discovery"

--- a/capa-controller-role/variables.tf
+++ b/capa-controller-role/variables.tf
@@ -14,13 +14,13 @@ variable "gs_user_account" {
   }
 }
 
-variable "management_cluster_oidc_provider_domain" {
+variable "management_cluster_oidc_provider" {
   type        = string
-  description = "OIDC provider domain of the management cluster"
+  description = "OIDC provider name of the management cluster"
 
   validation {
-    condition     = can(regex("^([0-9a-z-]+)(\\.[0-9a-z-]+)+$", var.management_cluster_oidc_provider_domain))
-    error_message = "Invalid OIDC provider domain"
+    condition     = can(regex("^([0-9a-z-]+)(\\.[0-9a-z-]+)+(\\/[0-9a-z-]+)*$", var.management_cluster_oidc_provider))
+    error_message = "Invalid OIDC provider name"
   }
 }
 


### PR DESCRIPTION
The "_domain" suffix wasn't really accurate, since the oidc name can be in a URL form like `s3.cn-north-1.amazonaws.com.cn/some-s3-bucket`, which we actually use for some China MCs.

I've fixed the validation Regex to accept that case and renamed the variable to a more suitable name.

## Checklist

- [x] Update changelog in CHANGELOG.md.
