### PR TITLE
Allow to override the principal ARN to assume the capa controller role

### DIFF
--- a/capa-controller-role/giantswarm-capa-role.tf
+++ b/capa-controller-role/giantswarm-capa-role.tf
@@ -2,6 +2,8 @@ locals {
   tags = {
     "installation" = var.installation_name
   }
+
+  principal_arn = coalesce(var.principal_arn_override, "arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:user/${var.installation_name}-capa-controller")
 }
 
 terraform {
@@ -19,11 +21,10 @@ data "aws_partition" "current" {}
 resource "aws_iam_role" "giantswarm_capa_controller_role" {
   name = "giantswarm-${var.installation_name}-capa-controller"
   assume_role_policy = templatefile("${path.module}/policies/trusted-entities.json", {
-    INSTALLATION_NAME                = var.installation_name
+    PRINCIPAL_ARN                    = local.principal_arn
     AWS_ACCOUNT_ID                   = data.aws_caller_identity.current.account_id
     MANAGEMENT_CLUSTER_OIDC_PROVIDER = var.management_cluster_oidc_provider
     AWS_PARTITION                    = data.aws_partition.current.partition
-    GS_USER_ACCOUNT                  = var.gs_user_account
   })
   tags        = local.tags
   description = "Giant Swarm managed role for k8s cluster creation"

--- a/capa-controller-role/policies/trusted-entities.json
+++ b/capa-controller-role/policies/trusted-entities.json
@@ -4,7 +4,7 @@
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:${AWS_PARTITION}:iam::${GS_USER_ACCOUNT}:user/${INSTALLATION_NAME}-capa-controller"
+                "AWS": "${PRINCIPAL_ARN}"
             },
             "Action": "sts:AssumeRole",
             "Condition": {}

--- a/capa-controller-role/variables.tf
+++ b/capa-controller-role/variables.tf
@@ -14,6 +14,12 @@ variable "gs_user_account" {
   }
 }
 
+variable "principal_arn_override" {
+  type        = string
+  description = "ARN of the principal that will assume the role. If omitted it will be inferred as 'arn:$${data.aws_partition.current.partition}:iam::$${var.gs_user_account}:user/$${var.installation_name}-capa-controller'."
+  default     = null
+}
+
 variable "management_cluster_oidc_provider" {
   type        = string
   description = "OIDC provider name of the management cluster"


### PR DESCRIPTION
This is needed for our wrapper Tofu project to be able to specify the actual IAM user arn as a dependency

## Checklist

- [ ] Update changelog in CHANGELOG.md.
