### PR TITLE
Add missing permissions for capa-iam-operator

### DIFF
--- a/capa-controller-role/policies/crossplane-policy.json
+++ b/capa-controller-role/policies/crossplane-policy.json
@@ -14,7 +14,18 @@
                 "ec2:RevokeSecurityGroupIngress",
                 "cloudwatch:*",
                 "sqs:*",
-                "events:*"
+                "events:*",
+                "iam:GetRole",
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:TagRole",
+                "iam:GetRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:ListRolePolicies",
+                "iam:DeleteRolePolicy",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:ListInstanceProfilesForRole"
             ],
             "Resource": "*"
         }

--- a/capa-controller-role/policies/crossplane-policy.json
+++ b/capa-controller-role/policies/crossplane-policy.json
@@ -19,12 +19,17 @@
                 "iam:CreateRole",
                 "iam:DeleteRole",
                 "iam:TagRole",
+                "iam:UntagRole",
                 "iam:GetRolePolicy",
                 "iam:PutRolePolicy",
                 "iam:ListRolePolicies",
                 "iam:DeleteRolePolicy",
                 "iam:AttachRolePolicy",
                 "iam:DetachRolePolicy",
+                "iam:GetPolicyVersion",
+                "iam:TagPolicy",
+                "iam:UntagPolicy",
+                "iam:ListPolicyVersions",
                 "iam:ListInstanceProfilesForRole"
             ],
             "Resource": "*"

--- a/capa-controller-role/policies/iam-controller-policy.json
+++ b/capa-controller-role/policies/iam-controller-policy.json
@@ -15,7 +15,8 @@
                 "iam:AttachRolePolicy",
                 "iam:DetachRolePolicy",
                 "iam:ListAttachedRolePolicies",
-                "iam:UpdateAssumeRolePolicy"
+                "iam:UpdateAssumeRolePolicy",
+                "iam:PassRole"
             ],
             "Resource": [
                 "arn:*:iam::*:role/*"


### PR DESCRIPTION
Towards https://github.com/giantswarm/straumann/issues/22

I missed some permissions on [the previous PR](https://github.com/giantswarm/giantswarm-aws-account-prerequisites/pull/149).