### PR TITLE
Trust new intermediary `GiantSwarmCustomerAccessAdmin` and `GiantSwarmCustomerAccessReadOnly` IAM roles which will become the exclusive way of accessing customer accounts after migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `GiantSwarmAdminCustomer` role to start migrating to stricter IAM role trust relationship
+
 ### Fixed
 
 - Fix incorrect IAM permission `cloudwatch:DeleteMetricFilter` to `logs:DeleteMetricFilter` in admin role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `GiantSwarmAdminCustomer` role to start migrating to stricter IAM role trust relationship
+- Trust new intermediary `GiantSwarmCustomerAccessAdmin` and `GiantSwarmCustomerAccessReadOnly` IAM roles which will become the exclusive way of accessing customer accounts after migration
 
 ### Fixed
 

--- a/admin-role/role.tf
+++ b/admin-role/role.tf
@@ -226,12 +226,28 @@ data "aws_iam_policy_document" "giantswarm_admin" {
 }
 
 data "aws_iam_policy_document" "giantswarm_admin_assume" {
+  # Migration to stricter IAM role trust relationship
+  #
+  # Trusting the whole Giant Swarm root account will be removed, and first assuming
+  # one of the `GiantSwarmCustomer*` roles will be required to access customer accounts.
+
   statement {
     effect = "Allow"
 
     principals {
       type        = "AWS"
       identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:root"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmCustomerAccessAdmin"]
     }
 
     actions = ["sts:AssumeRole"]
@@ -287,73 +303,5 @@ resource "aws_iam_role_policy_attachments_exclusive" "exclusive_policy_attachmen
 
 resource "aws_iam_role_policies_exclusive" "exclusive_inline_policies" {
   role_name    = aws_iam_role.giantswarm_admin.name
-  policy_names = keys(var.additional_policies)
-}
-
-// Migration to stricter IAM role trust relationship
-//
-// Compared to the previous `GiantSwarm` role, `GiantSwarmAdminCustomer` doesn't trust the whole Giant Swarm
-// root account, but only `role/GiantSwarmAdminInCustomerAccount`.
-
-data "aws_iam_policy_document" "giantswarm_admin_customer_assume" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmAdminInCustomerAccount"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
-resource "aws_iam_role" "giantswarm_admin_customer" {
-  name               = "GiantSwarmAdminCustomer"
-  assume_role_policy = data.aws_iam_policy_document.giantswarm_admin_customer_assume.json
-
-  # lifecycle {
-  #   prevent_destroy = true
-  # }
-}
-
-resource "aws_iam_policy" "giantswarm_admin_customer" {
-  name   = "GiantSwarmAdminCustomer"
-  policy = data.aws_iam_policy_document.giantswarm_admin.json
-
-  # lifecycle {
-  #   prevent_destroy = true
-  # }
-}
-
-resource "aws_iam_role_policy_attachment" "giantswarm_admin_customer" {
-  role       = aws_iam_role.giantswarm_admin_customer.name
-  policy_arn = aws_iam_policy.giantswarm_admin_customer.arn
-
-  # lifecycle {
-  #   prevent_destroy = true
-  # }
-}
-
-resource "aws_iam_role_policy" "giantswarm_admin_customer_additional" {
-  for_each = var.additional_policies
-  name     = each.key
-  role     = aws_iam_role.giantswarm_admin_customer.name
-  policy   = each.value
-}
-
-resource "aws_iam_role_policy_attachment" "giantswarm_admin_customer_additional" {
-  for_each   = toset(var.additional_policies_arns)
-  role       = aws_iam_role.giantswarm_admin_customer.name
-  policy_arn = each.value
-}
-
-resource "aws_iam_role_policy_attachments_exclusive" "giantswarm_admin_customer" {
-  role_name   = aws_iam_role.giantswarm_admin_customer.name
-  policy_arns = concat([aws_iam_policy.giantswarm_admin_customer.arn], var.additional_policies_arns)
-}
-
-resource "aws_iam_role_policies_exclusive" "giantswarm_admin_customer" {
-  role_name    = aws_iam_role.giantswarm_admin_customer.name
   policy_names = keys(var.additional_policies)
 }

--- a/admin-role/role.tf
+++ b/admin-role/role.tf
@@ -289,3 +289,71 @@ resource "aws_iam_role_policies_exclusive" "exclusive_inline_policies" {
   role_name    = aws_iam_role.giantswarm_admin.name
   policy_names = keys(var.additional_policies)
 }
+
+// Migration to stricter IAM role trust relationship
+//
+// Compared to the previous `GiantSwarm` role, `GiantSwarmAdminCustomer` doesn't trust the whole Giant Swarm
+// root account, but only `role/GiantSwarmAdminInCustomerAccount`.
+
+data "aws_iam_policy_document" "giantswarm_admin_customer_assume" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmAdminInCustomerAccount"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "giantswarm_admin_customer" {
+  name               = "GiantSwarmAdminCustomer"
+  assume_role_policy = data.aws_iam_policy_document.giantswarm_admin_customer_assume.json
+
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
+}
+
+resource "aws_iam_policy" "giantswarm_admin_customer" {
+  name   = "GiantSwarmAdminCustomer"
+  policy = data.aws_iam_policy_document.giantswarm_admin.json
+
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
+}
+
+resource "aws_iam_role_policy_attachment" "giantswarm_admin_customer" {
+  role       = aws_iam_role.giantswarm_admin_customer.name
+  policy_arn = aws_iam_policy.giantswarm_admin_customer.arn
+
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
+}
+
+resource "aws_iam_role_policy" "giantswarm_admin_customer_additional" {
+  for_each = var.additional_policies
+  name     = each.key
+  role     = aws_iam_role.giantswarm_admin_customer.name
+  policy   = each.value
+}
+
+resource "aws_iam_role_policy_attachment" "giantswarm_admin_customer_additional" {
+  for_each   = toset(var.additional_policies_arns)
+  role       = aws_iam_role.giantswarm_admin_customer.name
+  policy_arn = each.value
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "giantswarm_admin_customer" {
+  role_name   = aws_iam_role.giantswarm_admin_customer.name
+  policy_arns = concat([aws_iam_policy.giantswarm_admin_customer.arn], var.additional_policies_arns)
+}
+
+resource "aws_iam_role_policies_exclusive" "giantswarm_admin_customer" {
+  role_name    = aws_iam_role.giantswarm_admin_customer.name
+  policy_names = keys(var.additional_policies)
+}

--- a/admin-role/role.tf
+++ b/admin-role/role.tf
@@ -250,6 +250,8 @@ data "aws_iam_policy_document" "giantswarm_admin_assume" {
       identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmCustomerAccessAdmin"]
     }
 
+    # `sts:SetSourceIdentity` is used to allow passing a session description in the role chain
+    # so that audit logs (CloudTrail) show it.
     actions = ["sts:AssumeRole", "sts:SetSourceIdentity"]
   }
 }

--- a/admin-role/role.tf
+++ b/admin-role/role.tf
@@ -250,7 +250,7 @@ data "aws_iam_policy_document" "giantswarm_admin_assume" {
       identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmCustomerAccessAdmin"]
     }
 
-    actions = ["sts:AssumeRole"]
+    actions = ["sts:AssumeRole", "sts:SetSourceIdentity"]
   }
 }
 

--- a/read-role/role.tf
+++ b/read-role/role.tf
@@ -149,6 +149,31 @@ data "aws_iam_policy_document" "giantswarm_read_only_assume" {
 
     actions = ["sts:AssumeRole"]
   }
+
+  # Allow both the admin role (privileged users) and read-only role in the root account to
+  # assume the read-only role in the customer account:
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmCustomerAccessAdmin"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmCustomerAccessReadOnly"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
 }
 
 resource "aws_iam_role" "giantswarm_read_only" {

--- a/read-role/role.tf
+++ b/read-role/role.tf
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "giantswarm_read_only_assume" {
       identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmCustomerAccessAdmin"]
     }
 
-    actions = ["sts:AssumeRole"]
+    actions = ["sts:AssumeRole", "sts:SetSourceIdentity"]
   }
 
   statement {
@@ -172,7 +172,7 @@ data "aws_iam_policy_document" "giantswarm_read_only_assume" {
       identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmCustomerAccessReadOnly"]
     }
 
-    actions = ["sts:AssumeRole"]
+    actions = ["sts:AssumeRole", "sts:SetSourceIdentity"]
   }
 }
 

--- a/read-role/role.tf
+++ b/read-role/role.tf
@@ -161,6 +161,8 @@ data "aws_iam_policy_document" "giantswarm_read_only_assume" {
       identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmCustomerAccessAdmin"]
     }
 
+    # `sts:SetSourceIdentity` is used to allow passing a session description in the role chain
+    # so that audit logs (CloudTrail) show it.
     actions = ["sts:AssumeRole", "sts:SetSourceIdentity"]
   }
 
@@ -172,6 +174,8 @@ data "aws_iam_policy_document" "giantswarm_read_only_assume" {
       identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.gs_user_account}:role/GiantSwarmCustomerAccessReadOnly"]
     }
 
+    # `sts:SetSourceIdentity` is used to allow passing a session description in the role chain
+    # so that audit logs (CloudTrail) show it.
     actions = ["sts:AssumeRole", "sts:SetSourceIdentity"]
   }
 }


### PR DESCRIPTION
See [ticket](https://github.com/giantswarm/adidas/issues/1412) and [opsctl PR](https://github.com/giantswarm/opsctl/pull/2510)

## Checklist

- [x] Update changelog in CHANGELOG.md.
