### PR TITLE
Fix incorrect IAM permission `cloudwatch:DeleteMetricFilter` to `logs:DeleteMetricFilter` in admin role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix incorrect IAM permission `cloudwatch:DeleteMetricFilter` to `logs:DeleteMetricFilter` in admin role
+
 ## [7.7.0] - 2026-03-03
 
 ### Added

--- a/admin-role/role.tf
+++ b/admin-role/role.tf
@@ -219,7 +219,7 @@ data "aws_iam_policy_document" "giantswarm_admin" {
       "cloudwatch:DeleteAnomalyDetector",
       "cloudwatch:DeleteDashboards",
       "cloudwatch:DeleteInsightRules",
-      "cloudwatch:DeleteMetricFilter",
+      "logs:DeleteMetricFilter",
       "cloudwatch:DeleteMetricStream",
     ]
   }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35890

## Checklist

- [x] Update changelog in CHANGELOG.md.

## Summary

Fix incorrect IAM action `cloudwatch:DeleteMetricFilter` → `logs:DeleteMetricFilter` in the admin role. `DeleteMetricFilter` belongs to the CloudWatch Logs service (`logs:` prefix), not CloudWatch Metrics (`cloudwatch:` prefix).

I tested `tofu apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)