### PR TITLE
feat: add efs-csi-driver related permissions to Crossplane policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add efs-csi-driver related permissions to Crossplane policy
+
 ## [8.2.0] - 2026-05-20
 
 ### Added

--- a/crossplane/policies/crossplane-policy.json
+++ b/crossplane/policies/crossplane-policy.json
@@ -18,6 +18,7 @@
                 "ec2:DescribeSecurityGroupRules",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DetachNetworkInterface",
+                "ec2:DescribeSubnets",
                 "ec2:ModifyNetworkInterfaceAttribute",
                 "ec2:RevokeSecurityGroupEgress",
                 "ec2:RevokeSecurityGroupIngress",


### PR DESCRIPTION
These permissions are needed for Crossplane to manage efs mount targets

## Checklist

- [x] Update changelog in CHANGELOG.md.
